### PR TITLE
iOS 13.2+ fat macho kernels such as those found in t8010 and t8011 now remain fat after patching.

### DIFF
--- a/Kernel64Patcher.c
+++ b/Kernel64Patcher.c
@@ -99,8 +99,20 @@ int main(int argc, char **argv) {
         return -1;
     }
     
+    int is_fat = 0;
+    void* fat_buf;
     if (*(uint32_t*)kernel_buf == 0xbebafeca) {
         printf("%s: Detected fat macho kernel\n",__FUNCTION__);
+        
+        is_fat = 1;
+        fat_buf = (void*)malloc(28);
+        if(!fat_buf) {
+            printf("%s: Out of memory!\n", __FUNCTION__);
+            free(kernel_buf);
+            return -1;
+        }
+        memcpy(fat_buf, kernel_buf, 28);
+        
         memmove(kernel_buf,kernel_buf+28,kernel_len);
     }
     
@@ -119,6 +131,12 @@ int main(int argc, char **argv) {
         printf("%s: Unable to open %s!\n", __FUNCTION__, argv[2]);
         free(kernel_buf);
         return -1;
+    }
+    
+    if (is_fat == 1) {
+        memmove(kernel_buf, kernel_buf - 28, kernel_len);
+        memcpy(kernel_buf, fat_buf, 28);
+        free(fat_buf);
     }
     
     fwrite(kernel_buf, 1, kernel_len, fp);


### PR DESCRIPTION
Thus compareFiles.py now works on said kernels.